### PR TITLE
This fixes #1

### DIFF
--- a/lib/helm.js
+++ b/lib/helm.js
@@ -30,7 +30,11 @@ const HelmResultParser = function() {
       };
       const manifests = result.stdout.split('---').filter(removeNonManifests);
       const parseToJson = (manifest, nextManifest) => {
-        const source = manifest.split('\n').find(l => { return l.startsWith('# Source'); }).replace('# Source: ', '');
+        const sourceLine = manifest.split('\n').find(l => { return l.startsWith('# Source'); });
+        let source;
+        if (sourceLine) {
+          source = sourceLine.replace('# Source: ', '');
+        }
         let json;
         try {
           json = YAML.parse(manifest);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "async": "2.6.0",
     "colors": "1.1.2",
-    "command-exists": "1.2.2",
+    "command-exists": "1.2.6",
     "commander": "2.12.2",
     "istextorbinary": "2.1.0",
     "mocha": "4.1.0",


### PR DESCRIPTION
Assuming that the main goal to find `# Source` line is to remove them, I've added a failsafe to check whether the line is present in the manifest and proceed.