### PR TITLE
Feature/ Testing all charts & helm lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ There are some global helper variables defined for use in your tests:
 #### helm
 This is the root context and exposes the following functions:
 
-  - `withValueFile(path)`: Specify a value file to use when running helm, relative to the root of your chart.  You can call this multiple times
+  - `withValueFile([chartName/]path)`: Specify a value file to use when running helm, relative to the root of your chart.  You can call this multiple times
   - `set(key, value)`: Allows you to override a specific value, for example `set('service.port', '80')` would do `--set service.port=80` when running helm
-  - `go(done)`: Run a helm template generation and parse the output
+  - `go(done, [chartName])`: Run a helm template generation and parse the output
+  - `lint(done, [chartName])`: Run a helm lint
+
+ *`chartName` is an optional parameter but if you want to run helm-test on main folder (against all charts), you need to specify 'chartName'*
 
 #### yaml
 This global helper function allows you to parse yaml using `yamljs`.  This is useful for scenarios like a configmap containing a string block which sub contains yaml, that you wish to assert on.
@@ -97,6 +100,9 @@ Is a simple as doing `helm-test`:
 
 ### Constantly running tests and watching for changes
 You can have helm-test run every time it detects a change in your chart by simply doing `helm-test --watch`
+
+### Running tests against all helm charts
+You can have helm-test run on main folder to test all charts in subfolder by `helm-test --all` on main folder
 
 ## License
 Copyright (c) 2017 Karl Stoney

--- a/bin/helm-test
+++ b/bin/helm-test
@@ -12,10 +12,12 @@ const program = require('commander');
 program
   .version(version)
   .option('-w, --watch', 'Watch for file changes and re-run tests')
+  .option('-a, --all', 'Run test against all charts')
   .parse(process.argv);
 
 app.test({
-  watch: program.watch
+  watch: program.watch,
+  all: program.all
 }, err => {
   logger.log('Finished.');
   if(err) {

--- a/lib/all-globals.js
+++ b/lib/all-globals.js
@@ -1,5 +1,5 @@
 'use strict';
 const exec = new require('./exec')();
 const Helm = require('./helm');
-global.helm = new Helm(exec, '.');
+global.helm = new Helm(exec);
 global.yaml = require('yamljs');

--- a/lib/app.js
+++ b/lib/app.js
@@ -8,13 +8,18 @@ module.exports = function App(exec) {
   self.test = function(options, done) {
     const execOptions = { output: true, cwd: process.cwd() };
     const mocha = path.join(__dirname, '../node_modules/mocha/bin/mocha');
-    const globals = path.join(__dirname, 'globals.js');
+    let globals = path.join(__dirname, 'globals.js');
+    let pattern = 'tests'
+    if(options.all) {
+      globals = path.join(__dirname, 'all-globals.js');
+      pattern = './**/tests/*.js';
+    }
     let watch = '';
     if(options.watch) {
       logger.log('Watching for file changes enabled.');
       watch = ' --watch --watch-extensions yaml,tpl';
     }
-    const command = `${mocha}${watch} -r should -r ${globals} --recursive tests`;
+    const command = `${mocha}${watch} -r should -r ${globals} --recursive ${pattern}`;
     logger.log('Testing...');
     exec.command(command, execOptions, done);
   };

--- a/lib/helm.js
+++ b/lib/helm.js
@@ -60,11 +60,17 @@ const HelmResultParser = function() {
 };
 const helmResultParser = new HelmResultParser();
 
-module.exports = function Helm(exec) {
+module.exports = function Helm(exec, chartPath) {
   let self = {};
   let files = [];
   let sets = [];
   self.withValueFile = function(valueFile) {
+    if (chartPath) {
+      let paths = valueFile.split('/');
+      if (paths.length > 1) {
+        valueFile = paths[1];
+      }
+    }
     const pathToValueFile = path.join(process.cwd(), valueFile);
     files.push(pathToValueFile);
     return self;
@@ -73,8 +79,10 @@ module.exports = function Helm(exec) {
     sets.push(key + '=' + value);
     return self;
   };
-  self.go = function(done) {
-    let command = 'helm template .';
+  self.go = function(done, path) {
+    path = chartPath || path || '.';
+    let command = `helm template ${path}`;
+    console.log(files.join(' -f '));
     if(files.length > 0) {
       command = command + ' -f ' + files.join(' -f ');
     }
@@ -88,5 +96,13 @@ module.exports = function Helm(exec) {
     exec.command(command, options, helmResultParser.parse(done));
     return self;
   };
+  self.lint = function(done, path) {
+    path = chartPath || path || '.';
+    let command = `helm lint ${path}`;
+
+    const options = { output: true };
+    exec.command(command, options, helmResultParser.parse(done));
+    return self;
+  }
   return Object.freeze(self);
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "helm-test",
   "description": "A CLI to test Helm charts",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "homepage": "https://github.com/Stono/helm-test",
   "author": {
     "name": "Karl Stoney",

--- a/test/helm.js
+++ b/test/helm.js
@@ -7,12 +7,33 @@ describe('Helm', () => {
   beforeEach(() => {
     exec = deride.stub(['command']);
     exec.setup.command.toCallbackWith([null, { stdout: '' }]);
-    helm = new Helm(exec);
   });
-  it('should accept value files', () => {
-    helm.withValueFile('some-file.yaml');
+  describe('Specific charts', () => {
+    beforeEach(() => {
+      helm = new Helm(exec, '.');
+    });
+    it('should accept value files', () => {
+      helm.withValueFile('some-file.yaml');
+    });
+    it('should run a helm template', done => {
+      helm.go(done);
+    });
+    it('should run a helm lint', done => {
+      helm.lint(done);
+    });
   });
-  it('should run a helm template', done => {
-    helm.go(done);
+  describe('All charts', () => {
+    beforeEach(() => {
+      helm = new Helm(exec);
+    });
+    it('should accept value files', () => {
+      helm.withValueFile('chart-name/some-file.yaml');
+    });
+    it('should run a helm template', done => {
+      helm.go(done, 'chart-name');
+    });
+    it('should run a helm lint', done => {
+      helm.lint(done, 'chart-name');
+    });
   });
 });


### PR DESCRIPTION
Adding 2 new features
1. Can run helm-test against all charts on main folder by executing command `helm-test --all`
but it's required `chartName` in helm helper if want to test all charts
- `withValueFile([chartName/]path)`
- `go(done, [chartName])`

   It still supports testing a single chart by current command `helm-test` in chart folder
```
/
  chart-1/
    Chart.yaml
    values.yaml
    charts/
    templates/
    tests/
      your-tests.js
      some-more-tests.js
  chart-2/
  more-charts/
```

2. Add helm lint
- `lint(done, [chartName])`