### PR TITLE
Don't swallow errors that have to do with runtime execution

### DIFF
--- a/bin/helm-test
+++ b/bin/helm-test
@@ -17,8 +17,9 @@ program
 app.test({
   watch: program.watch
 }, err => {
-  logger.log('Finished.');
   if(err) {
+    logger.log(err);
     process.exit(1);
   }
+  logger.log('Finished.');
 });


### PR DESCRIPTION
This isn't 100% ideal because it will print a stack trace when there are no tests found, but this will at least help scenarios like #6 where the mocha binary cannot be found due to relative path issues:

```
$ /home/gplasky/node_modules/helm-test/bin/helm-test
  helm-test [info] Welcome to helm-test v0.1.18! +0ms
  helm-test [info] Testing... +0ms
  helm-test [info] Finished. +10ms
  helm-test [info] { Error: spawn /home/gplasky/node_modules/helm-test/node_modules/mocha/bin/mocha ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:231:19)
    at onErrorNT (internal/child_process.js:406:16)
    at process._tickCallback (internal/process/next_tick.js:63:19)
    at Function.Module.runMain (internal/modules/cjs/loader.js:745:11)
    at startup (internal/bootstrap/node.js:266:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:596:3)
  errno: 'ENOENT',
  code: 'ENOENT',
  syscall:
   'spawn /home/gplasky/node_modules/helm-test/node_modules/mocha/bin/mocha',
  path:
   '/home/gplasky/node_modules/helm-test/node_modules/mocha/bin/mocha',
  spawnargs:
   [ 'debug',
     '-r',
     'should',
     '-r',
     '/home/gplasky/node_modules/helm-test/lib/globals.js',
     '--recursive',
     'tests' ] } +0ms
```

A separate PR is required to address that underlying issue.