### PR TITLE
Correctly split manifests

### DIFF
--- a/lib/helm.js
+++ b/lib/helm.js
@@ -28,7 +28,7 @@ const HelmResultParser = function() {
       const removeNonManifests = manifest => {
         return manifest.length > 0;
       };
-      const manifests = result.stdout.split('---').filter(removeNonManifests);
+      const manifests = result.stdout.split(/\r?\n---/).filter(removeNonManifests);
       /* jshint maxcomplexity: 6 */
       const parseToJson = (manifest, nextManifest) => {
         const sourceLine = manifest.split('\n').find(l => { return l.startsWith('# Source'); });


### PR DESCRIPTION
Tests will fail if, for example, the content of a ConfigMap data has '---' in it.
For example:
```
Kind: ConfigMap
name: test
data:
  somefile: |-
    ---