### PR TITLE
Switch yaml parser from `yamljs` to `js-yaml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ This is the root context and exposes the following functions:
   - `go(done)`: Run a helm template generation and parse the output
 
 #### yaml
-This global helper function allows you to parse yaml using `yamljs`.  This is useful for scenarios like a configmap containing a string block which sub contains yaml, that you wish to assert on.
+This global helper function allows you to parse yaml using `js-yaml`.  This is useful for scenarios like a configmap containing a string block which sub contains yaml, that you wish to assert on.
 
 eg.
 ```
-const json = yaml.parse(results.ofType('ConfigMap')[0].spec.data);
+const json = yaml.safeLoad(results.ofType('ConfigMap')[0].spec.data);
 json.metadata.name.should.eql('some-manifest');
 ```
 

--- a/lib/globals.js
+++ b/lib/globals.js
@@ -2,4 +2,4 @@
 const exec = new require('./exec')();
 const Helm = require('./helm');
 global.helm = new Helm(exec);
-global.yaml = require('yamljs');
+global.yaml = require('js-yaml');

--- a/lib/helm.js
+++ b/lib/helm.js
@@ -4,7 +4,7 @@ const process = require('process');
 const async = require('async');
 const HelmResultParser = function() {
   const logger = new require('./logger')('parser');
-  const YAML = require('yamljs');
+  const YAML = require('js-yaml');
 
   let self = {};
   self.parse = function(done) {
@@ -38,7 +38,7 @@ const HelmResultParser = function() {
         }
         let json;
         try {
-          json = YAML.parse(manifest);
+          json = YAML.safeLoad(manifest);
         } catch(ex) {
           const err = new Error('Failed to parse manifest: ' + source);
           logger.error(err);

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "command-exists": "1.2.6",
     "commander": "2.15.1",
     "istextorbinary": "2.2.1",
+    "js-yaml": "3.13.1",
     "mocha": "5.2.0",
-    "should": "13.2.1",
-    "yamljs": "0.3.0"
+    "should": "13.2.1"
   },
   "devDependencies": {
     "deride": "1.2.0",


### PR DESCRIPTION
`yamljs` is a bit too forgiving when parsing yaml documents and won't
raise exceptions for things like duplicate keys within an object.

Switching out `yamljs` to `js-yaml` solves this problem, as it is a more
strict parser.