### PR TITLE
Fix helm version extraction

### DIFF
--- a/lib/helm.js
+++ b/lib/helm.js
@@ -69,10 +69,16 @@ module.exports = function Helm(exec) {
     3: 'helm template --namespace default release-name .'
   };
 
-  const helmVersion = exec.commandSync('helm version --client --short').stdout
-  let version = 2
-  if (helmVersion && helmVersion.startsWith('Client: v')) {
-    version = parseInt(helmVersion.replace('Client: v', '')[0])
+  let version = -1;
+
+  const helmVersion = exec.commandSync('helm version --client --short').stdout;
+  const helmVersionRegExp = new RegExp('v(?<major>[0-9])+\.[0-9]+\.[0-9]+');
+  const helmVersionRegExpMatches = helmVersion ? helmVersion.match(helmVersionRegExp) : null;
+
+  if (helmVersionRegExpMatches) {
+    version = parseInt(helmVersionRegExpMatches.groups.major);
+  } else {
+    throw new Error(`Cannot parse helm version: ${helmVersion}`);
   }
 
   if (version !== 2 && version !== 3) {


### PR DESCRIPTION
Helm (as of 3.5) doesn't print 'Client: v' in helm version output.
Use RegExp to match helm version which is more reliable and make sure to throw an error if version is wrong or there is a parsing error.